### PR TITLE
Do not modify score at all if no points were gained

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,17 +195,23 @@ function renderGameHistory (playerNames, allScores) {
 
 // Game
 
+function updateScore (totalSoFar, newPoints) {
+  let newTotal = totalSoFar + newPoints
+
+  if (newTotal % 50 === 0) {
+    newTotal = newTotal / 2
+  }
+
+  return newTotal
+}
+
 function calculateScore (scores, totals) {
   const newTotals = []
 
   for (let i = 0; i < scores.length; i++) {
-    let newTotal = totals[i] + scores[i]
-
-    if (newTotal % 50 === 0) {
-      newTotal = newTotal / 2
-    }
-
-    newTotals.push(newTotal)
+    newTotals.push(
+      updateScore(totals[i], scores[i])
+    )
   }
 
   return newTotals

--- a/index.js
+++ b/index.js
@@ -196,6 +196,10 @@ function renderGameHistory (playerNames, allScores) {
 // Game
 
 function updateScore (totalSoFar, newPoints) {
+  if (newPoints === 0) {
+    return totalSoFar
+  }
+
   let newTotal = totalSoFar + newPoints
 
   if (newTotal % 50 === 0) {


### PR DESCRIPTION
This returns early if no points were gained, to avoid treating the
current score like a new score that has been arrived at.

This fixes a problem whereby a player with points that are a multiple
of 50 would have their points halve if they gained no new points in
a round.

Fixes #7